### PR TITLE
Handle function

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -69,7 +69,7 @@ impl Expression {
     /// key correspond to name of function and value is a pair containing
     /// name of variables and definition of function
     pub fn replace_functions(&mut self, _functions: &HashMap<String, (Vec<String>, String)>) {
-        // todo!();
+        // TODO
     }
 }
 
@@ -163,19 +163,83 @@ mod tests {
         variables.insert(String::from("velocity"), 3.43);
         variables.insert(String::from("time"), 5.9954);
 
-        let raw_expression: String = String::from("y = (x - 2.75) + velocity * time");
+        let var_expression: String = String::from("y = (x - 2.75) + velocity * time");
 
-        let replaced_raw_expression: String = format!(
+        let replaced_var_expression: String = format!(
             "({} - 2.75) + {} * {}",
             variables["x"], variables["velocity"], variables["time"]
         );
 
-        let mut expression: Expression = Expression::new(raw_expression.as_str());
+        let mut expression: Expression = Expression::new(var_expression.as_str());
         expression.replace_variables(&variables);
 
         match expression {
             Expression::Variable(_, replaced_expression) => {
+                assert_eq!(replaced_var_expression, replaced_expression)
+            }
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_expression_replace_functions_in_raw_expression() {
+        let mut functions: HashMap<String, (Vec<String>, String)> = HashMap::new();
+
+        functions.insert(
+            String::from("distance"),
+            (
+                vec![String::from("x"), String::from("y")],
+                String::from("x * x + y * y"),
+            ),
+        );
+
+        functions.insert(
+            String::from("f"),
+            (vec![String::from("a")], String::from("a + 1")),
+        );
+
+        let raw_expression: String = String::from("distance(2.0, 3.3) + f(5.2) * 3");
+        let replaced_raw_expression: String =
+            String::from("(2.0 * 2.0 + 3.3 * 3.3) + (5.2 + 1) * 3");
+
+        let mut expression: Expression = Expression::new(raw_expression.as_str());
+        expression.replace_functions(&functions);
+
+        match expression {
+            Expression::Raw(replaced_expression) => {
                 assert_eq!(replaced_raw_expression, replaced_expression)
+            }
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_expression_replace_functions_in_variable_expression() {
+        let mut functions: HashMap<String, (Vec<String>, String)> = HashMap::new();
+
+        functions.insert(
+            String::from("distance"),
+            (
+                vec![String::from("x"), String::from("y")],
+                String::from("x * x + y * y"),
+            ),
+        );
+
+        functions.insert(
+            String::from("f"),
+            (vec![String::from("a")], String::from("a + 1")),
+        );
+
+        let var_expression: String = String::from("d = distance(2.0, 3.3) + f(5.2) * 3");
+        let replaced_var_expression: String =
+            String::from("(2.0 * 2.0 + 3.3 * 3.3) + (5.2 + 1) * 3");
+
+        let mut expression: Expression = Expression::new(var_expression.as_str());
+        expression.replace_functions(&functions);
+
+        match expression {
+            Expression::Variable(_, replaced_expression) => {
+                assert_eq!(replaced_var_expression, replaced_expression)
             }
             _ => assert!(false),
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -63,6 +63,14 @@ impl Expression {
             let _ = std::mem::swap(definition, &mut replaced_definition);
         }
     }
+
+    /// Replace all function contained in expression by their definition
+    /// The function are given in argument through HashMap where
+    /// key correspond to name of function and value is a pair containing
+    /// name of variables and definition of function
+    pub fn replace_functions(&mut self, _functions: &HashMap<String, (Vec<String>, String)>) {
+        // todo!();
+    }
 }
 
 #[cfg(test)]

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -68,8 +68,34 @@ impl Expression {
     /// The function are given in argument through HashMap where
     /// key correspond to name of function and value is a pair containing
     /// name of variables and definition of function
-    pub fn replace_functions(&mut self, _functions: &HashMap<String, (Vec<String>, String)>) {
-        // TODO
+    pub fn replace_functions(&mut self, functions: &HashMap<String, (Vec<String>, String)>) {
+        let definition: &mut String = match self {
+            Self::Raw(raw_expression) => raw_expression,
+            Self::Variable(_, definition) => definition,
+            Self::Function(_, _, definition) => definition,
+        };
+
+        while let Some(fun_name) = functions
+            .keys()
+            .find(|&fun_name| definition.contains(fun_name))
+        {
+            let start_position: usize = definition.find(fun_name.as_str()).unwrap();
+
+            if let Some(end_position) = definition
+                .chars()
+                .skip(start_position + fun_name.len())
+                .position(|c| c == ')')
+            {
+                // create string to replace function call
+                // TODO
+                let mut replaced_fun_definition: String = functions[fun_name].1.clone();
+
+                definition.replace_range(
+                    start_position..=end_position,
+                    replaced_fun_definition.as_str(),
+                );
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,12 +445,12 @@ mod tests {
             .is_ok());
 
         let expression: String = format!(
-            "3.14 * {}({}(2.4, 4.3), 5.43) + (2 * 3 - 7)",
+            "3.14 * {}(6.89, 5.43) - {}(2.4, 4.3) + (2 * 3 - 7)",
             second_function_name, first_function_name
         );
 
         let replaced_expression: String =
-            String::from("3.14 * ((2.4 * 2.4 + 4.3 * 4.3) / 5.43) + (2 * 3 - 7)");
+            String::from("3.14 * (6.89 / 5.43) - (2.4 * 2.4 + 4.3 * 4.3) + (2 * 3 - 7)");
 
         match calculator.process(expression.as_str()) {
             Ok(str_result) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ where
     pub fn process(&mut self, expression_str: &str) -> Result<String, String> {
         let mut expression: Expression = Expression::new(expression_str);
 
-        expression.replace_functions(&self.functions);
+        expression.replace_functions(&self.functions)?;
         expression.replace_variables(&self.variables);
 
         let result: String = match expression {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,4 +460,87 @@ mod tests {
             Err(_) => assert!(false),
         }
     }
+
+    #[test]
+    fn test_calculator_process_expression_with_variables_and_functions() {
+        let mut calculator = Calculator::new(evaluate);
+
+        let first_function_name: String = String::from("distance");
+        let first_function_variables: Vec<String> = vec![String::from("x"), String::from("y")];
+        let first_function_definition: String = format!(
+            "{} * {} + {} * {}",
+            first_function_variables[0],
+            first_function_variables[0],
+            first_function_variables[1],
+            first_function_variables[1]
+        );
+
+        let first_function_expression: String = format!(
+            "{}: {}, {} = {}",
+            first_function_name,
+            first_function_variables[0],
+            first_function_variables[1],
+            first_function_definition
+        );
+
+        assert!(calculator
+            .process(first_function_expression.as_str())
+            .is_ok());
+
+        let second_function_name: String = String::from("velocity");
+        let second_function_variables: Vec<String> =
+            vec![String::from("distance"), String::from("time")];
+
+        let second_function_definition: String = format!(
+            "{} / {}",
+            second_function_variables[0], second_function_variables[1]
+        );
+
+        let second_function_expression: String = format!(
+            "{}: {}, {} = {}",
+            second_function_name,
+            second_function_variables[0],
+            second_function_variables[1],
+            second_function_definition
+        );
+
+        assert!(calculator
+            .process(second_function_expression.as_str())
+            .is_ok());
+
+        let first_variable_name: String = String::from("x");
+        let first_variable_definition: String = String::from("1 + 1");
+
+        let first_expression: String =
+            format!("{} = {}", first_variable_name, first_variable_definition);
+
+        assert!(calculator.process(first_expression.as_str()).is_ok());
+
+        let second_variable_name: String = String::from("y");
+        let second_variable_definition: String = String::from("97 + 1");
+
+        let second_expression: String =
+            format!("{} = {}", second_variable_name, second_variable_definition);
+
+        assert!(calculator.process(second_expression.as_str()).is_ok());
+
+        let expression: String = format!(
+            "3.14 * {}({}, {}) - {}(2.4, 4.3) + (2 * 3 - 7)",
+            second_function_name, first_variable_name, second_variable_name, first_function_name
+        );
+
+        let replaced_expression: String = format!(
+            "3.14 * ({} / {}) - (2.4 * 2.4 + 4.3 * 4.3) + (2 * 3 - 7)",
+            first_variable_definition.len(),
+            second_variable_definition.len()
+        );
+
+        match calculator.process(expression.as_str()) {
+            Ok(str_result) => {
+                let str_reference: String = format!("last = {}", replaced_expression.len());
+                assert_eq!(str_result, str_reference);
+            }
+            Err(_) => assert!(false),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ where
             Expression::Variable(name, definition) => {
                 (name, (self.evaluator)(definition.as_str())?)
             }
+            Expression::Function(_, _, _) => todo!(),
         };
 
         self.variables.insert(name.clone(), value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,4 +273,191 @@ mod tests {
             Err(_) => assert!(false),
         }
     }
+
+    #[test]
+    fn test_calculator_process_function_expression() {
+        let mut calculator = Calculator::new(evaluate);
+
+        let function_name: String = String::from("distance");
+        let function_variables: Vec<String> = vec![String::from("x"), String::from("y")];
+        let function_definition: String = format!(
+            "{} * {} + {} * {}",
+            function_variables[0],
+            function_variables[0],
+            function_variables[1],
+            function_variables[1]
+        );
+
+        let expression: String = format!(
+            "{}: {}, {} = {}",
+            function_name, function_variables[0], function_variables[1], function_definition
+        );
+
+        match calculator.process(expression.as_str()) {
+            Ok(str_result) => {
+                let str_reference: String = format!(
+                    "{}({}) = {}",
+                    function_name,
+                    function_variables.join(", "),
+                    function_definition
+                );
+
+                assert_eq!(str_result, str_reference);
+
+                assert_eq!(calculator.functions.len(), 1);
+                assert!(calculator.functions.contains_key(&function_name));
+                assert_eq!(
+                    calculator.functions[&function_name],
+                    (function_variables, function_definition)
+                );
+            }
+            Err(_) => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_calculator_process_several_function_expression() {
+        let mut calculator = Calculator::new(evaluate);
+
+        let first_function_name: String = String::from("distance");
+        let first_function_variables: Vec<String> = vec![String::from("x"), String::from("y")];
+        let first_function_definition: String = format!(
+            "{} * {} + {} * {}",
+            first_function_variables[0],
+            first_function_variables[0],
+            first_function_variables[1],
+            first_function_variables[1]
+        );
+
+        let first_expression: String = format!(
+            "{}: {}, {} = {}",
+            first_function_name,
+            first_function_variables[0],
+            first_function_variables[1],
+            first_function_definition
+        );
+
+        match calculator.process(first_expression.as_str()) {
+            Ok(str_result) => {
+                let str_reference: String = format!(
+                    "{}({}) = {}",
+                    first_function_name,
+                    first_function_variables.join(", "),
+                    first_function_definition
+                );
+
+                assert_eq!(str_result, str_reference);
+
+                assert_eq!(calculator.functions.len(), 1);
+                assert!(calculator.functions.contains_key(&first_function_name));
+                assert_eq!(
+                    calculator.functions[&first_function_name],
+                    (first_function_variables, first_function_definition)
+                );
+            }
+            Err(_) => assert!(false),
+        }
+
+        let second_function_name: String = String::from("velocity");
+        let second_function_variables: Vec<String> =
+            vec![String::from("distance"), String::from("time")];
+
+        let second_function_definition: String = format!(
+            "{} / {}",
+            second_function_variables[0], second_function_variables[1]
+        );
+
+        let second_expression: String = format!(
+            "{}: {}, {} = {}",
+            second_function_name,
+            second_function_variables[0],
+            second_function_variables[1],
+            second_function_definition
+        );
+
+        match calculator.process(second_expression.as_str()) {
+            Ok(str_result) => {
+                let str_reference: String = format!(
+                    "{}({}) = {}",
+                    second_function_name,
+                    second_function_variables.join(", "),
+                    second_function_definition
+                );
+
+                assert_eq!(str_result, str_reference);
+
+                assert_eq!(calculator.functions.len(), 2);
+                assert!(calculator.functions.contains_key(&second_function_name));
+                assert_eq!(
+                    calculator.functions[&second_function_name],
+                    (second_function_variables, second_function_definition)
+                );
+            }
+            Err(_) => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_calculator_process_expression_with_functions() {
+        let mut calculator = Calculator::new(evaluate);
+
+        let first_function_name: String = String::from("distance");
+        let first_function_variables: Vec<String> = vec![String::from("x"), String::from("y")];
+        let first_function_definition: String = format!(
+            "{} * {} + {} * {}",
+            first_function_variables[0],
+            first_function_variables[0],
+            first_function_variables[1],
+            first_function_variables[1]
+        );
+
+        let first_function_expression: String = format!(
+            "{}: {}, {} = {}",
+            first_function_name,
+            first_function_variables[0],
+            first_function_variables[1],
+            first_function_definition
+        );
+
+        assert!(calculator
+            .process(first_function_expression.as_str())
+            .is_ok());
+
+        let second_function_name: String = String::from("velocity");
+        let second_function_variables: Vec<String> =
+            vec![String::from("distance"), String::from("time")];
+
+        let second_function_definition: String = format!(
+            "{} / {}",
+            second_function_variables[0], second_function_variables[1]
+        );
+
+        let second_function_expression: String = format!(
+            "{}: {}, {} = {}",
+            second_function_name,
+            second_function_variables[0],
+            second_function_variables[1],
+            second_function_definition
+        );
+
+        assert!(calculator
+            .process(second_function_expression.as_str())
+            .is_ok());
+
+        let expression: String = format!(
+            "3.14 * {}({}(2.4, 4.3), 5.43) + (2 * 3 - 7)",
+            second_function_name, first_function_name
+        );
+
+        let replaced_expression: String =
+            String::from("3.14 * ((2.4 * 2.4 + 4.3 * 4.3) / 5.43) + (2 * 3 - 7)");
+
+        match calculator.process(expression.as_str()) {
+            Ok(str_result) => {
+                let str_reference: String = format!("last = {}", replaced_expression.len());
+                assert_eq!(str_result, str_reference);
+            }
+            Err(_) => assert!(false),
+        }
+    }
 }


### PR DESCRIPTION
To create a function we use following syntax:
`fun_name: fun_var_1, fun_var_2, ... = fun_definition`

With that, calculator store function into hash map which associate function name with tuple (vector of variable, function definition).
Then, we can call a function with following syntax:
`fun_name(fun_var_1, fun_var_2,...)`