### PR TITLE
Fix issue when function variables have same name that user defined variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tazor"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Bastian Gonzalez Acevedo <bastiangonzalezacevedo@gmail.com>"]
 edition = "2021"
 license-file = "LICENSE"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -57,18 +57,31 @@ impl Expression {
     /// The variables are given in argument through HashMap where
     /// pair (key, value) correspond respectively to name and value of variable
     pub fn replace_variables(&mut self, variables: &HashMap<String, f64>) {
-        let definition: &mut String = match self {
-            Self::Raw(raw_expression) => raw_expression,
-            Self::Variable(_, definition) => definition,
-            Self::Function(_, _, definition) => definition,
+        match self {
+            Self::Raw(definition) | Self::Variable(_, definition) => {
+                variables
+                    .iter()
+                    .for_each(|(variable_name, variable_value)| {
+                        let mut replaced_definition: String = definition
+                            .replace(variable_name, format!("{}", variable_value).as_str());
+
+                        core::mem::swap(definition, &mut replaced_definition);
+                    });
+            }
+            Self::Function(_, function_variables, definition) => {
+                variables
+                    .iter()
+                    .filter(|(variable_name, _)| {
+                        return !function_variables.contains(variable_name);
+                    })
+                    .for_each(|(variable_name, variable_value)| {
+                        let mut replaced_definition: String = definition
+                            .replace(variable_name, format!("{}", variable_value).as_str());
+
+                        core::mem::swap(definition, &mut replaced_definition);
+                    });
+            }
         };
-
-        for (variable_name, variable_value) in variables {
-            let mut replaced_definition: String =
-                definition.replace(variable_name, format!("{}", variable_value).as_str());
-
-            core::mem::swap(definition, &mut replaced_definition);
-        }
     }
 
     /// Recovery positions of function and its parenthesis in expression definition

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,4 +636,44 @@ mod tests {
             Err(_) => assert!(false),
         }
     }
+
+    #[test]
+    fn test_calculator_process_expression_with_variables_and_function_variables_equal_to_variables()
+    {
+        let mut calculator = Calculator::new(evaluate);
+
+        let first_variable_name: String = String::from("x");
+        let first_variable_definition: String = String::from("1 + 1");
+
+        let first_expression: String =
+            format!("{} = {}", first_variable_name, first_variable_definition);
+
+        assert!(calculator.process(first_expression.as_str()).is_ok());
+
+        let second_variable_name: String = String::from("y");
+        let second_variables_definition: String = String::from("2 * 5");
+
+        let second_expression: String =
+            format!("{} = {}", second_variable_name, second_variables_definition);
+
+        assert!(calculator.process(second_expression.as_str()).is_ok());
+
+        let function_name: String = String::from("distance");
+        let function_variables: Vec<String> = vec![String::from("x"), String::from("y")];
+        let function_definition: String = format!(
+            "{} * {} + {} * {}",
+            function_variables[0],
+            function_variables[0],
+            function_variables[1],
+            function_variables[1]
+        );
+
+        let function_expression: String = format!(
+            "{}: {}, {} = {}",
+            function_name, function_variables[0], function_variables[1], function_definition
+        );
+
+        assert!(calculator.process(function_expression.as_str()).is_ok());
+        assert!(function_definition == calculator.functions[&function_name].1);
+    }
 }


### PR DESCRIPTION
#3 
When we replace variables by its values, we check before if name does not correspond to function variables name. We do this only for expression representing function.